### PR TITLE
fixed usage of _pair(..) function to reference Adafruit_SSD1306 (Adaf…

### DIFF
--- a/mjs_fs/api_arduino_ssd1306.js
+++ b/mjs_fs/api_arduino_ssd1306.js
@@ -125,39 +125,39 @@ let Adafruit_SSD1306 = {
     },
 
     drawCircle: function(x0, y0, r, color) {
-      return Adafruit_SSD1306._dc(this.ssd, _pair(x0, y0), r, color);
+      return Adafruit_SSD1306._dc(this.ssd, Adafruit_SSD1306._pair(x0, y0), r, color);
     },
 
     drawCircleHelper: function(x0, y0, r, cornername, color) {
-      return Adafruit_SSD1306._dch(this.ssd, _pair(x0, y0), r, cornername, color);
+      return Adafruit_SSD1306._dch(this.ssd, Adafruit_SSD1306._pair(x0, y0), r, cornername, color);
     },
 
     fillCircle: function(x0, y0, r, color) {
-      return Adafruit_SSD1306._fc(this.ssd, _pair(x0, y0), r, color);
+      return Adafruit_SSD1306._fc(this.ssd, Adafruit_SSD1306._pair(x0, y0), r, color);
     },
 
     fillCircleHelper: function(x0, y0, r, cornername, delta, color) {
-      return Adafruit_SSD1306._fch(this.ssd, _pair(x0, y0), r, cornername, delta, color);
+      return Adafruit_SSD1306._fch(this.ssd, Adafruit_SSD1306._pair(x0, y0), r, cornername, delta, color);
     },
 
     drawTriangle: function(x0, y0, x1, y1, x2, y2, color) {
-      return Adafruit_SSD1306._dt(this.ssd, _pair(x0, y0), _pair(x1, y1), _pair(x2, y2), color);
+      return Adafruit_SSD1306._dt(this.ssd, Adafruit_SSD1306._pair(x0, y0), Adafruit_SSD1306._pair(x1, y1), Adafruit_SSD1306._pair(x2, y2), color);
     },
 
     fillTriangle: function(x0, y0, x1, y1, x2, y2, color) {
-      return Adafruit_SSD1306._ft(this.ssd, _pair(x0, y0), _pair(x1, y1), _pair(x2, y2), color);
+      return Adafruit_SSD1306._ft(this.ssd, Adafruit_SSD1306._pair(x0, y0), Adafruit_SSD1306._pair(x1, y1), Adafruit_SSD1306._pair(x2, y2), color);
     },
 
     drawRoundRect: function(x0, y0, w, h, radius, color) {
-      return Adafruit_SSD1306._drr(this.ssd, _pair(x0, y0), w, h, radius, color);
+      return Adafruit_SSD1306._drr(this.ssd, Adafruit_SSD1306._pair(x0, y0), w, h, radius, color);
     },
 
     fillRoundRect: function(x0, y0, w, h, radius, color) {
-      return Adafruit_SSD1306._frr(this.ssd, _pair(x0, y0), w, h, radius, color);
+      return Adafruit_SSD1306._frr(this.ssd, Adafruit_SSD1306._pair(x0, y0), w, h, radius, color);
     },
 
     drawChar: function(x, y, c, color, bg, size) {
-      return Adafruit_SSD1306._dch(this.ssd, _pair(x, y), c, color, bg, size);
+      return Adafruit_SSD1306._dch(this.ssd, Adafruit_SSD1306._pair(x, y), c, color, bg, size);
     },
 
     setCursor: function(x, y) {
@@ -227,4 +227,4 @@ let Adafruit_SSD1306 = {
     obj.ssd = Adafruit_SSD1306._cspi(dc, rst, cs, res);
     return obj;
   },
-}
+};


### PR DESCRIPTION
_pair() function didn't correctly reference the Adafruit_SSD1306 object it belonged to so all Adafruit_SSD1306 draw functions that relied on it failed.